### PR TITLE
Remove error message from private constructors

### DIFF
--- a/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/visitors/ClassTypeVisitor.java
+++ b/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/visitors/ClassTypeVisitor.java
@@ -29,7 +29,6 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
-import javax.tools.Diagnostic;
 
 public class ClassTypeVisitor extends TsElement {
 
@@ -152,12 +151,6 @@ public class ClassTypeVisitor extends TsElement {
         && !superTsElement.isTsInterface()
         && !superTsElement.isTsIgnored()) {
 
-      if (superTsElement.requiresProtectedConstructor()) {
-        env.messager()
-            .printMessage(
-                Diagnostic.Kind.ERROR, "Cannot extend a type with private constructor.", element);
-        return Optional.empty();
-      }
       TsClass.TsClassBuilder builder =
           TsClass.builder(superTsElement.getName(), superTsElement.getNamespace());
       new TypeArgumentsVisitor<TsClass.TsClassBuilder>(superclass, env).visit(builder);

--- a/jsinterop-ts-defs-processor/src/test/resources/types/ctors/JsTypeWithMultipleIgnoredConstructors.java
+++ b/jsinterop-ts-defs-processor/src/test/resources/types/ctors/JsTypeWithMultipleIgnoredConstructors.java
@@ -4,6 +4,7 @@ import jsinterop.annotations.*;
 
 @JsType
 public class JsTypeWithMultipleIgnoredConstructors {
+    public void go() {}
 
     @JsIgnore
     public JsTypeWithMultipleIgnoredConstructors(){
@@ -11,5 +12,11 @@ public class JsTypeWithMultipleIgnoredConstructors {
 
     @JsIgnore
     public JsTypeWithMultipleIgnoredConstructors(String lastName) {
+    }
+
+    public static class SubclassWithParentIgnoredConstructor extends JsTypeWithMultipleIgnoredConstructors {
+        @JsMethod
+        public void stop() {}
+
     }
 }


### PR DESCRIPTION
Follow-up fix to #11, removing the error message that talks about private constructors, and adding a test case.

Fixes #10