### PR TITLE
Varargs appear as an array without `...`

### DIFF
--- a/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsProperty.java
+++ b/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsProperty.java
@@ -31,6 +31,7 @@ public class TsProperty {
   private TsDoc tsDoc;
   private boolean jsOptional;
   private boolean deprecated;
+  private boolean varargs = false;
   private List<TsModifier> modifiers = new ArrayList<>();
 
   private TsProperty(String name, TsType type) {
@@ -48,6 +49,9 @@ public class TsProperty {
     }
     sb.append(modifiers.stream().map(TsModifier::emit).collect(Collectors.joining("", "", "")));
 
+    if (varargs) {
+      sb.append("...");
+    }
     sb.append(resolveName(name));
     if (jsOptional) {
       sb.append("?");
@@ -89,6 +93,11 @@ public class TsProperty {
 
     public TsPropertyBuilder setDeprecated(boolean deprecated) {
       this.property.deprecated = deprecated;
+      return this;
+    }
+
+    public TsPropertyBuilder setVarargs(boolean varargs) {
+      this.property.varargs = varargs;
       return this;
     }
 

--- a/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/visitors/ParameterVisitor.java
+++ b/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/visitors/ParameterVisitor.java
@@ -73,10 +73,16 @@ public class ParameterVisitor<T> extends TsElement {
     } else {
       type = getType();
     }
+    ExecutableElement parentElement = (ExecutableElement) element.getEnclosingElement();
+
     parent.addProperty(
         TsProperty.builder(getName(), type)
             .addModifiers(getJsModifiers())
             .setOptional(isJsOptional())
+            .setVarargs(
+                parentElement.isVarArgs()
+                    && (parentElement.getParameters().indexOf(element)
+                        == (parentElement.getParameters().size() - 1)))
             .build());
   }
 }

--- a/jsinterop-ts-defs-processor/src/test/java/com/vertispan/tsdefs/types/varargs/JsTypeWithVarargsMethod.java
+++ b/jsinterop-ts-defs-processor/src/test/java/com/vertispan/tsdefs/types/varargs/JsTypeWithVarargsMethod.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2023 Vertispan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vertispan.tsdefs.types.varargs;
+
+import jsinterop.annotations.JsType;
+
+@JsType
+public class JsTypeWithVarargsMethod {
+
+  public String doSomething(int[] x, String... args) {
+    return "";
+  }
+
+  public String doSomething2(String... args) {
+    return "";
+  }
+
+  public String doSomething3(String[] args) {
+    return "";
+  }
+}


### PR DESCRIPTION
Fix #18 to include `...` varargs typescript output.