### PR TITLE
stop generating readonly modifier for final classes

### DIFF
--- a/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsClass.java
+++ b/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsClass.java
@@ -97,7 +97,11 @@ public class TsClass implements IsType {
     if (nonNull(tsDoc)) {
       sb.append(tsDoc.emit(indent, deprecated));
     }
-    sb.append(modifiers.stream().map(TsModifier::emit).collect(Collectors.joining("")));
+    sb.append(
+        modifiers.stream()
+            .filter(tsModifier -> TsModifier.READONLY != tsModifier)
+            .map(TsModifier::emit)
+            .collect(Collectors.joining("")));
     sb.append("class ");
     sb.append(emitType(parentNamespace));
     if (nonNull(superClass)) {

--- a/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsMethod.java
+++ b/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsMethod.java
@@ -61,13 +61,17 @@ public class TsMethod {
     if (nonNull(tsDoc)) {
       sb.append(tsDoc.emit(indent, deprecated));
     }
-    sb.append(modifiers.stream().map(TsModifier::emit).collect(Collectors.joining(NONE)));
+    sb.append(
+        modifiers.stream()
+            .filter(tsModifier -> TsModifier.READONLY != tsModifier)
+            .map(TsModifier::emit)
+            .collect(Collectors.joining(NONE)));
 
     sb.append(name);
     sb.append("(");
     sb.append(
         parameters.stream()
-            .map(property -> property.emit(NONE, NONE, parentNamespace))
+            .map(property -> property.emitAsParameter(parentNamespace))
             .collect(Collectors.joining(COMMA)));
 
     sb.append(")");

--- a/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsProperty.java
+++ b/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsProperty.java
@@ -15,6 +15,7 @@
  */
 package com.vertispan.tsdefs.model;
 
+import static com.vertispan.tsdefs.Formatting.NONE;
 import static com.vertispan.tsdefs.Formatting.resolveName;
 import static java.util.Objects.nonNull;
 
@@ -40,6 +41,11 @@ public class TsProperty {
   }
 
   public String emit(String indent, String ending, String parentNamespace) {
+    return emitProperty(indent, ending, parentNamespace, false);
+  }
+
+  private String emitProperty(
+      String indent, String ending, String parentNamespace, boolean skipModifiers) {
     StringBuffer sb = new StringBuffer();
 
     if (nonNull(tsDoc)) {
@@ -47,7 +53,9 @@ public class TsProperty {
     } else if (deprecated) {
       sb.append(Deprecation.emit(indent));
     }
-    sb.append(modifiers.stream().map(TsModifier::emit).collect(Collectors.joining("", "", "")));
+    if (!skipModifiers) {
+      sb.append(modifiers.stream().map(TsModifier::emit).collect(Collectors.joining("", "", "")));
+    }
 
     if (varargs) {
       sb.append("...");
@@ -61,6 +69,10 @@ public class TsProperty {
     sb.append(ending);
 
     return sb.toString();
+  }
+
+  public String emitAsParameter(String parentNamespace) {
+    return emitProperty(NONE, NONE, parentNamespace, true);
   }
 
   public static TsPropertyBuilder builder(String name, TsType type) {

--- a/jsinterop-ts-defs-processor/src/test/java/com/vertispan/tsdefs/jsclasses/FinalJsType.java
+++ b/jsinterop-ts-defs-processor/src/test/java/com/vertispan/tsdefs/jsclasses/FinalJsType.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2023 Vertispan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vertispan.tsdefs.jsclasses;
+
+import jsinterop.annotations.JsType;
+
+/*
+Test that final modifier will not produce a readonly modifier in type script
+By just having this class the TS tests will fail to compile the result .d.ts file and produce an error if if has readonly modifier.
+ */
+@JsType
+public final class FinalJsType {
+  public String property;
+
+  public final void doSomething(final String name) {}
+}


### PR DESCRIPTION
fix #37 Final java classes shouldn't be marked as "readonly" in typescript