### PR TITLE
fix public exportable TsInterface members are not exported.

### DIFF
--- a/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/ArrayTsType.java
+++ b/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/ArrayTsType.java
@@ -29,4 +29,9 @@ public class ArrayTsType extends TsType {
   public String emit(String parentNamespace) {
     return super.emit(parentNamespace) + "[]";
   }
+
+  @Override
+  public boolean equals(Object o) {
+    return (o instanceof ArrayTsType) && super.equals(o);
+  }
 }

--- a/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/NoneTsType.java
+++ b/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/NoneTsType.java
@@ -24,4 +24,9 @@ public class NoneTsType extends TsType {
   public String emit(String parentNamespace) {
     return "";
   }
+
+  @Override
+  public boolean equals(Object o) {
+    return (o instanceof NoneTsType) && super.equals(o);
+  }
 }

--- a/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/ParameterizedTsType.java
+++ b/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/ParameterizedTsType.java
@@ -19,11 +19,12 @@ import static com.vertispan.tsdefs.Formatting.optionalAffix;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class ParameterizedTsType extends TsType {
 
-  private List<TsType> typeArguments = new ArrayList<>();
+  private final List<TsType> typeArguments = new ArrayList<>();
 
   public static ParameterizedTsType of(String name, String namespace, List<TsType> typeArguments) {
     return new ParameterizedTsType(name, namespace, typeArguments);
@@ -48,5 +49,19 @@ public class ParameterizedTsType extends TsType {
         .collect(
             Collectors.joining(
                 ",", optionalAffix("<", typeArguments), optionalAffix(">", typeArguments)));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof ParameterizedTsType)) return false;
+    if (!super.equals(o)) return false;
+    ParameterizedTsType that = (ParameterizedTsType) o;
+    return typeArguments.equals(that.typeArguments);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), typeArguments);
   }
 }

--- a/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsClass.java
+++ b/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsClass.java
@@ -21,7 +21,9 @@ import static java.util.Objects.nonNull;
 import com.vertispan.tsdefs.builders.*;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class TsClass implements IsType {
@@ -31,9 +33,9 @@ public class TsClass implements IsType {
   private TsClass superClass;
   private List<TsInterface> interfaces = new ArrayList<>();
   private List<TsModifier> modifiers = new ArrayList<>();
-  private List<TsProperty> properties = new ArrayList<>();
+  private Set<TsProperty> properties = new LinkedHashSet<>();
   private TsConstructor constructor;
-  private List<TsMethod> functions = new ArrayList<>();
+  private Set<TsMethod> functions = new LinkedHashSet<>();
   private List<TsType> typeArguments = new ArrayList<>();
   private TsDoc tsDoc;
   private boolean deprecated;

--- a/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsCustomType.java
+++ b/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsCustomType.java
@@ -15,6 +15,8 @@
  */
 package com.vertispan.tsdefs.model;
 
+import java.util.Objects;
+
 public class TsCustomType extends TsType {
   private final TsType referenceType;
 
@@ -40,5 +42,19 @@ public class TsCustomType extends TsType {
     sb.append(";");
 
     return sb.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof TsCustomType)) return false;
+    if (!super.equals(o)) return false;
+    TsCustomType that = (TsCustomType) o;
+    return Objects.equals(referenceType, that.referenceType);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), referenceType);
   }
 }

--- a/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsInlinedFunctionType.java
+++ b/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsInlinedFunctionType.java
@@ -18,6 +18,7 @@ package com.vertispan.tsdefs.model;
 import com.vertispan.tsdefs.builders.HasProperties;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class TsInlinedFunctionType extends TsType implements HasProperties<TsInlinedFunctionType> {
@@ -51,5 +52,20 @@ public class TsInlinedFunctionType extends TsType implements HasProperties<TsInl
     return properties.stream()
         .map(property -> property.emit("", "", ""))
         .collect(Collectors.joining(","));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof TsInlinedFunctionType)) return false;
+    if (!super.equals(o)) return false;
+    TsInlinedFunctionType that = (TsInlinedFunctionType) o;
+    return Objects.equals(properties, that.properties)
+        && Objects.equals(getReturnType(), that.getReturnType());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), properties, getReturnType());
   }
 }

--- a/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsMethod.java
+++ b/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsMethod.java
@@ -23,6 +23,7 @@ import com.vertispan.tsdefs.builders.HasProperties;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class TsMethod {
@@ -117,5 +118,20 @@ public class TsMethod {
     public TsMethod build() {
       return this.method;
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof TsMethod)) return false;
+    TsMethod tsMethod = (TsMethod) o;
+    return Objects.equals(getName(), tsMethod.getName())
+        && Objects.equals(returnType, tsMethod.returnType)
+        && Objects.equals(parameters, tsMethod.parameters);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getName(), returnType, parameters);
   }
 }

--- a/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsProperty.java
+++ b/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsProperty.java
@@ -23,6 +23,7 @@ import com.vertispan.tsdefs.builders.HasDocs;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class TsProperty {
@@ -61,6 +62,19 @@ public class TsProperty {
     sb.append(ending);
 
     return sb.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof TsProperty)) return false;
+    TsProperty that = (TsProperty) o;
+    return Objects.equals(name, that.name) && Objects.equals(type, that.type);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
   }
 
   public static TsPropertyBuilder builder(String name, TsType type) {

--- a/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsTemplatedInlinedType.java
+++ b/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsTemplatedInlinedType.java
@@ -15,6 +15,8 @@
  */
 package com.vertispan.tsdefs.model;
 
+import java.util.Objects;
+
 public class TsTemplatedInlinedType extends TsType {
   private String template;
   private TsType type;
@@ -32,5 +34,19 @@ public class TsTemplatedInlinedType extends TsType {
   @Override
   public String emit(String parentNamespace) {
     return template.replace("$T", type.emit(parentNamespace));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof TsTemplatedInlinedType)) return false;
+    if (!super.equals(o)) return false;
+    TsTemplatedInlinedType that = (TsTemplatedInlinedType) o;
+    return Objects.equals(template, that.template) && Objects.equals(type, that.type);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), template, type);
   }
 }

--- a/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsType.java
+++ b/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/model/TsType.java
@@ -19,6 +19,7 @@ import static com.vertispan.tsdefs.Formatting.resolveName;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class TsType {
@@ -81,5 +82,20 @@ public class TsType {
         + bounds.stream()
             .map(tsType -> tsType.emit(parentNamespace))
             .collect(Collectors.joining(" & "));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof TsType)) return false;
+    TsType tsType = (TsType) o;
+    return Objects.equals(getName(), tsType.getName())
+        && Objects.equals(getNamespace(), tsType.getNamespace())
+        && Objects.equals(bounds, tsType.bounds);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getName(), getNamespace());
   }
 }

--- a/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/visitors/ClassTypeVisitor.java
+++ b/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/visitors/ClassTypeVisitor.java
@@ -72,16 +72,13 @@ public class ClassTypeVisitor extends TsElement {
           .ifPresent(
               superclass -> {
                 TsElement superTsElement = TsElement.of(superclass, env);
-                if (superTsElement.isTsIgnored()) {
+                if (superTsElement.isTsIgnored() || superTsElement.isTsInterface()) {
                   TsClass.TsClassBuilder superBuilder =
                       TsClass.builder(superTsElement.getName(), superTsElement.getNamespace());
                   superTsElement
                       .element()
                       .getEnclosedElements()
-                      .forEach(
-                          e -> {
-                            visit(superBuilder, e);
-                          });
+                      .forEach(e -> visit(superBuilder, e));
                   TsClass superTsClass = superBuilder.build();
                   tsClass.mergeFunctions(superTsClass);
                   tsClass.mergeProperties(superTsClass);

--- a/jsinterop-ts-defs-processor/src/test/java/com/vertispan/tsdefs/tsinterface/TsInterfaceType.java
+++ b/jsinterop-ts-defs-processor/src/test/java/com/vertispan/tsdefs/tsinterface/TsInterfaceType.java
@@ -13,25 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.vertispan.tsdefs.model;
+package com.vertispan.tsdefs.tsinterface;
 
-public class Array2dTsType extends ArrayTsType {
+import com.vertispan.tsdefs.annotations.TsInterface;
+import jsinterop.annotations.JsProperty;
 
-  public static Array2dTsType of(TsType tsType) {
-    return new Array2dTsType(tsType);
-  }
-
-  public Array2dTsType(TsType arrayComponent) {
-    super(arrayComponent);
-  }
-
-  @Override
-  public String emit(String parentNamespace) {
-    return super.emit(parentNamespace) + "[]";
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    return (o instanceof Array2dTsType) && super.equals(o);
-  }
+@TsInterface
+public class TsInterfaceType {
+  @JsProperty public String property;
 }

--- a/jsinterop-ts-defs-processor/src/test/java/com/vertispan/tsdefs/tsinterface/TypeExtendingTsInterfaceType.java
+++ b/jsinterop-ts-defs-processor/src/test/java/com/vertispan/tsdefs/tsinterface/TypeExtendingTsInterfaceType.java
@@ -13,25 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.vertispan.tsdefs.model;
+package com.vertispan.tsdefs.tsinterface;
 
-public class Array2dTsType extends ArrayTsType {
+import jsinterop.annotations.JsType;
 
-  public static Array2dTsType of(TsType tsType) {
-    return new Array2dTsType(tsType);
-  }
-
-  public Array2dTsType(TsType arrayComponent) {
-    super(arrayComponent);
-  }
-
-  @Override
-  public String emit(String parentNamespace) {
-    return super.emit(parentNamespace) + "[]";
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    return (o instanceof Array2dTsType) && super.equals(o);
-  }
-}
+@JsType
+public class TypeExtendingTsInterfaceType extends TsInterfaceType {}

--- a/jsinterop-ts-defs-processor/src/test/resources/types/test.ts
+++ b/jsinterop-ts-defs-processor/src/test/resources/types/test.ts
@@ -81,6 +81,8 @@ import TsIgnoredSuperClass = com.vertispan.tsdefs.inheritance.TsIgnoredSuperClas
 import JsTypeExtendsTsIgnoredSuperType = com.vertispan.tsdefs.inheritance.JsTypeExtendsTsIgnoredSuperType;
 import JsTypeWithJsNullableMembers = com.vertispan.tsdefs.jsnullable.JsTypeWithJsNullableMembers;
 
+import TypeExtendingTsInterfaceType = com.vertispan.tsdefs.tsinterface.TypeExtendingTsInterfaceType;
+
 // ---------- Properties tests -------------------------
 const jsTypeWithProperties = new JsTypeWithProperties();
 
@@ -697,3 +699,10 @@ jsTypeWithJsNullableMembers.notNullable = jsTypeWithJsNullableMembers.notNullabl
 // @ts-expect-error
 jsTypeWithJsNullableMembers.notNullable = jsTypeWithJsNullableMembers.nullableMethod();
 jsTypeWithJsNullableMembers.nullableProperty = jsTypeWithJsNullableMembers.nullableMethod();
+
+
+// ----------------- TsInterface --------------------
+
+const typeExtendingTsInterfaceType = new TypeExtendingTsInterfaceType();
+// $ExpectType string
+typeExtendingTsInterfaceType.property;


### PR DESCRIPTION
Public fields from JsTypes are exported, this pull request fix public fields from TsInterface super class not being exported.