### PR TITLE
Shaded jars do not include jsinterop-annotations, and do not depend on them

### DIFF
--- a/jsinterop-ts-defs-doclet/pom.xml
+++ b/jsinterop-ts-defs-doclet/pom.xml
@@ -27,7 +27,14 @@
             <artifactId>jsinterop-ts-defs-impl</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.google.jsinterop/jsinterop-annotations -->
+        <dependency>
+            <groupId>com.google.jsinterop</groupId>
+            <artifactId>jsinterop-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.jsinterop</groupId>
+            <artifactId>base</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.google.elemental2</groupId>
             <artifactId>elemental2-core</artifactId>

--- a/jsinterop-ts-defs-processor/pom.xml
+++ b/jsinterop-ts-defs-processor/pom.xml
@@ -28,6 +28,14 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.jsinterop</groupId>
+            <artifactId>jsinterop-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.jsinterop</groupId>
+            <artifactId>base</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.elemental2</groupId>
             <artifactId>elemental2-core</artifactId>
             <version>1.1.0</version>


### PR DESCRIPTION
Fix #86