### PR TITLE
@links to Java methods annotated with @JsProperty do not resolve correctly in Typescript

### DIFF
--- a/jsinterop-ts-defs-doclet/src/main/java/com/vertispan/tsdefs/doclet/TsDocTreeVisitor.java
+++ b/jsinterop-ts-defs-doclet/src/main/java/com/vertispan/tsdefs/doclet/TsDocTreeVisitor.java
@@ -21,6 +21,7 @@ import com.sun.source.doctree.*;
 import com.sun.source.util.DocTreePath;
 import com.sun.source.util.DocTrees;
 import com.sun.source.util.SimpleDocTreeVisitor;
+import com.vertispan.tsdefs.impl.Formatting;
 import com.vertispan.tsdefs.impl.HasProcessorEnv;
 import com.vertispan.tsdefs.impl.builders.TsElement;
 import java.util.Optional;
@@ -67,7 +68,12 @@ public class TsDocTreeVisitor extends SimpleDocTreeVisitor<String, Element> {
                 String refNamespace = refTsElement.getNamespace();
                 String parentNamespace = parentTsElement.getNamespace();
 
-                String name = refTsElement.getName();
+                boolean isSetterOrGetter = refTsElement.isSetter() || refTsElement.isGetter();
+
+                String name =
+                    isSetterOrGetter
+                        ? Formatting.nonGetSetName(refTsElement.getName())
+                        : refTsElement.getName();
                 String parentName = parentTsElement.getName();
                 if (refNamespace.equals(parentNamespace)) {
                   String fullName = refNamespace + "." + parentName + "." + name;
@@ -127,7 +133,7 @@ public class TsDocTreeVisitor extends SimpleDocTreeVisitor<String, Element> {
         node.getBlockTags().stream()
             .map(tag -> tag.accept(this, element))
             .collect(Collectors.joining("\n"));
-    return body + "\n" + tags;
+    return " " + body + "\n" + tags;
   }
 
   @Override
@@ -145,6 +151,6 @@ public class TsDocTreeVisitor extends SimpleDocTreeVisitor<String, Element> {
 
   @Override
   public String visitText(TextTree node, Element element) {
-    return " " + node.getBody();
+    return "" + node.getBody();
   }
 }

--- a/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/links/methods/MyClass.java
+++ b/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/links/methods/MyClass.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2023 Vertispan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vertispan.tsdefs.tests.tsdocs.doclet.links.methods;
+
+import jsinterop.annotations.JsProperty;
+
+/** The entire point of this class is to let you use {@link #getSomethingImportant()}. */
+public class MyClass {
+  @JsProperty
+  public String getSomethingImportant() {
+    return null;
+  }
+}


### PR DESCRIPTION
Fix #87