### PR TITLE
A breaking change seems part of the latest tslint

### DIFF
--- a/jsinterop-ts-defs-test/pom.xml
+++ b/jsinterop-ts-defs-test/pom.xml
@@ -97,7 +97,7 @@
                             "install", so unless you need to run some other npm command,
                             you can remove this whole <configuration> section.
                             -->
-                            <arguments>install --prefix ${project.build.directory}/test-classes --save-dev @definitelytyped/dtslint typescript</arguments>
+                            <arguments>install --prefix ${project.build.directory}/test-classes --save-dev @definitelytyped/dtslint@0.0.182 typescript</arguments>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
we no longer can build due to missing notNeededPackages.json

```
[INFO] Error: ENOENT: no such file or directory, open '/home/runner/work/jsinterop-ts-defs/jsinterop-ts-defs/jsinterop-ts-defs-test/target/test-classes/notNeededPackages.json'
[INFO] npm ERR! code ELIFECYCLE
[INFO] npm ERR! errno 1
[INFO] npm ERR! @ dtslint: `dtslint types`
[INFO] npm ERR! Exit status 1
```