### PR TITLE
Correctly emit protected constructors

### DIFF
--- a/jsinterop-ts-defs-impl/src/main/java/com/vertispan/tsdefs/impl/builders/TsElement.java
+++ b/jsinterop-ts-defs-impl/src/main/java/com/vertispan/tsdefs/impl/builders/TsElement.java
@@ -752,18 +752,11 @@ public class TsElement {
 
   public boolean requiresProtectedConstructor() {
     if (isJsType()) {
-      List<TsElement> constructors =
-          element.getEnclosedElements().stream()
-              .map(enclosedElement -> TsElement.of(enclosedElement, env))
-              .filter(TsElement::isConstructor)
-              .collect(Collectors.toList());
-      boolean allIgnored =
-          !constructors.isEmpty() && constructors.stream().allMatch(TsElement::isIgnored);
-
-      if (allIgnored) {
-        return true;
-      }
-
+      return element.getEnclosedElements().stream()
+          .map(enclosedElement -> TsElement.of(enclosedElement, env))
+          .filter(TsElement::isConstructor)
+          .filter(tsElement -> !tsElement.isPrivate())
+          .allMatch(TsElement::isIgnored);
     } else {
       Optional<TsElement> jsConstructor =
           element.getEnclosedElements().stream()

--- a/jsinterop-ts-defs-test/src/test/java/com/vertispan/tsdefs/tests/constructors/JsTypeWithPrivateAndIgnoredConstructors.java
+++ b/jsinterop-ts-defs-test/src/test/java/com/vertispan/tsdefs/tests/constructors/JsTypeWithPrivateAndIgnoredConstructors.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2023 Vertispan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vertispan.tsdefs.tests.constructors;
+
+import jsinterop.annotations.JsIgnore;
+import jsinterop.annotations.JsType;
+
+@JsType
+public class JsTypeWithPrivateAndIgnoredConstructors {
+
+  public String property1;
+  public String property2;
+
+  private JsTypeWithPrivateAndIgnoredConstructors(String property) {
+    this.property1 = property;
+    this.property2 = property;
+  }
+
+  @JsIgnore
+  public JsTypeWithPrivateAndIgnoredConstructors(String property1, String property2) {
+    this.property1 = property1;
+    this.property2 = property2;
+  }
+}

--- a/jsinterop-ts-defs-test/src/test/resources/types/test.ts
+++ b/jsinterop-ts-defs-test/src/test/resources/types/test.ts
@@ -115,7 +115,7 @@ import JsInterfaceWithIgnoredMembers = com.vertispan.tsdefs.tests.tsignore.JsInt
 
 import JsTypeGrandChild = com.vertispan.tsdefs.tests.inheritance.JsTypeGrandChild;
 import JsTypeGrandChild2 = com.vertispan.tsdefs.tests.inheritance.JsTypeGrandChild2;
-
+import JsTypeWithPrivateAndIgnoredConstructors = com.vertispan.tsdefs.tests.constructors.JsTypeWithPrivateAndIgnoredConstructors;
 // ---------- Properties tests -------------------------
 const jsTypeWithProperties = new JsTypeWithProperties();
 
@@ -1036,5 +1036,18 @@ class ImplementsUnionTypeApiUndefined implements UnionTypeApi {
 
     arraysFunction(param1: Array<number | Array<number | undefined | null>>, param2: Array<number | Array<number | undefined | null>>): number | Array<Array<number | Array<number | undefined | null>>> | undefined | null {
         return undefined;
+    }
+}
+
+// @ts-expect-error
+const jsTypeWithPrivateAndIgnoredConstructors= new JsTypeWithPrivateAndIgnoredConstructors();
+// @ts-expect-error
+const jsTypeWithPrivateAndIgnoredConstructors= new JsTypeWithPrivateAndIgnoredConstructors("property");
+// @ts-expect-error
+const jsTypeWithPrivateAndIgnoredConstructors= new JsTypeWithPrivateAndIgnoredConstructors("property1", "property2");
+
+class ExtendsFromJsTypeWithPrivateAndIgnoredConstructors extends JsTypeWithPrivateAndIgnoredConstructors {
+    constructor() {
+        super();
     }
 }


### PR DESCRIPTION
if a class has a private constructors and all other constructors are ignored, we should be emitting a protected constructor. currently we dont since we dont filter for private constructors. this commit should fix that