### PR TITLE
Correctly emit return and params docs

### DIFF
--- a/jsinterop-ts-defs-doclet/src/main/java/com/vertispan/tsdefs/doclet/TsDocTreeVisitor.java
+++ b/jsinterop-ts-defs-doclet/src/main/java/com/vertispan/tsdefs/doclet/TsDocTreeVisitor.java
@@ -151,6 +151,24 @@ public class TsDocTreeVisitor extends SimpleDocTreeVisitor<String, Element> {
 
   @Override
   public String visitText(TextTree node, Element element) {
-    return "" + node.getBody();
+    return node.getBody();
+  }
+
+  @Override
+  public String visitReturn(ReturnTree node, Element element) {
+    return "@return "
+        + node.getDescription().stream()
+            .map(docTree -> docTree.accept(this, element))
+            .collect(Collectors.joining());
+  }
+
+  @Override
+  public String visitParam(ParamTree node, Element element) {
+    return (node.isTypeParameter() ? "@typeParam " : "@param ")
+        + node.getName()
+        + " - "
+        + node.getDescription().stream()
+            .map(docTree -> docTree.accept(this, element))
+            .collect(Collectors.joining());
   }
 }

--- a/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/links/methods/JsTypeLinksMethods.java
+++ b/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/links/methods/JsTypeLinksMethods.java
@@ -19,6 +19,7 @@ import com.vertispan.tsdefs.tests.tsdocs.doclet.links.methods.nested.JsTypeC;
 import com.vertispan.tsdefs.tests.tsdocs.doclet.links.methods.nested.JsTypeD;
 import com.vertispan.tsdefs.tests.tsdocs.doclet.links.methods.nested.JsTypeE;
 import com.vertispan.tsdefs.tests.tsdocs.doclet.links.methods.nested.JsTypeF;
+import elemental2.promise.Promise;
 import jsinterop.annotations.JsType;
 
 /**
@@ -64,4 +65,9 @@ public class JsTypeLinksMethods {
   }
 
   public void doSomethingA2() {}
+
+  /** @return {@link Promise} of {@link JsTypeC} */
+  public Promise<JsTypeC> getTypeC() {
+    return null;
+  }
 }

--- a/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/links/types/ParametrizedTypes.java
+++ b/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/links/types/ParametrizedTypes.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2023 Vertispan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vertispan.tsdefs.tests.tsdocs.doclet.links.types;
+
+import elemental2.promise.Promise;
+import jsinterop.annotations.JsType;
+
+/**
+ * Represents a class that demonstrates the use of parametrized types.
+ *
+ * @param <T> the type of parameter this class operates on
+ */
+@JsType
+public class ParametrizedTypes<T> {
+
+  /**
+   * Retrieves a Promise containing the provided parameter.
+   *
+   * @param param1 a {@link Promise} of type T
+   * @param param2 an additional string parameter
+   * @return a {@link Promise} containing the value of type T
+   */
+  public Promise<T> getParameter(Promise<T> param1, String param2) {
+    // Implementation here
+    return null;
+  }
+}


### PR DESCRIPTION
This commit fixes the handling of @return and @param and converts them into proper typedocs @return, @param or @typeparam.