### PR TITLE
TsIgnore prevents interface members from being present on subtypes

### DIFF
--- a/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/DocletTest.java
+++ b/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/DocletTest.java
@@ -67,4 +67,9 @@ public class DocletTest {
   public void testMethodsLinks() throws IOException {
     testDocs("links.methods");
   }
+
+  @Test
+  public void testIssue99() throws IOException {
+    testDocs("links.issue99");
+  }
 }

--- a/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/links/issue99/JsTypeGrandChild.java
+++ b/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/links/issue99/JsTypeGrandChild.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2024 Vertispan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vertispan.tsdefs.tests.tsdocs.doclet.links.issue99;
+
+import jsinterop.annotations.JsType;
+
+@JsType
+public class JsTypeGrandChild extends NonJsTypeParent {
+
+  public String propertyFromA;
+
+  public String doSomethingFromA() {
+    return "";
+  }
+}

--- a/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/links/issue99/NonJsTypeParent.java
+++ b/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/links/issue99/NonJsTypeParent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2024 Vertispan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vertispan.tsdefs.tests.tsdocs.doclet.links.issue99;
+
+import com.vertispan.tsdefs.annotations.TsIgnore;
+
+@TsIgnore
+public class NonJsTypeParent extends TsInterfaceParent {
+
+  public String propertyFromB;
+
+  public String doSomethingFromB() {
+    return "";
+  }
+}

--- a/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/links/issue99/TsInterfaceParent.java
+++ b/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/links/issue99/TsInterfaceParent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2024 Vertispan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vertispan.tsdefs.tests.tsdocs.doclet.links.issue99;
+
+import com.vertispan.tsdefs.annotations.TsInterface;
+import jsinterop.annotations.JsType;
+
+@TsInterface
+@JsType
+public class TsInterfaceParent {
+  public String propertyFromC;
+
+  public String doSomethingFromC() {
+    return "";
+  }
+}

--- a/jsinterop-ts-defs-impl/src/main/java/com/vertispan/tsdefs/impl/visitors/ClassTypeVisitor.java
+++ b/jsinterop-ts-defs-impl/src/main/java/com/vertispan/tsdefs/impl/visitors/ClassTypeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Vertispan
+ * Copyright © 2024 Vertispan
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,21 +89,26 @@ public class ClassTypeVisitor extends TsElement {
 
   private void processSuperClass(TsClass tsClass, TypeMirror superclass) {
     TsElement superTsElement = TsElement.of(superclass, env);
+
     if (superTsElement.isTsIgnored() || superTsElement.isTsInterface()) {
-      TsClass.TsClassBuilder superBuilder =
-          TsClass.builder(superTsElement.getName(), superTsElement.getNamespace());
-      superTsElement.element().getEnclosedElements().forEach(e -> visit(superBuilder, e));
-      TsClass superTsClass = superBuilder.build();
-      tsClass.mergeFunctions(superTsClass);
-      tsClass.mergeProperties(superTsClass);
-    } else {
-      superTsElement
-          .getJavaSuperClass()
-          .ifPresent(
-              typeMirror -> {
-                processSuperClass(tsClass, typeMirror);
-              });
+      mergeSuperClass(tsClass, superTsElement);
     }
+
+    superTsElement
+        .getJavaSuperClass()
+        .ifPresent(
+            typeMirror -> {
+              processSuperClass(tsClass, typeMirror);
+            });
+  }
+
+  private void mergeSuperClass(TsClass tsClass, TsElement superTsElement) {
+    TsClass.TsClassBuilder superBuilder =
+        TsClass.builder(superTsElement.getName(), superTsElement.getNamespace());
+    superTsElement.element().getEnclosedElements().forEach(e -> visit(superBuilder, e));
+    TsClass superTsClass = superBuilder.build();
+    tsClass.mergeFunctions(superTsClass);
+    tsClass.mergeProperties(superTsClass);
   }
 
   private boolean isSameNameSpaceAsParent(TsElement e) {

--- a/jsinterop-ts-defs-test/src/test/java/com/vertispan/tsdefs/tests/inheritance/JsTypeGrandChildOfTsIgnoredParent.java
+++ b/jsinterop-ts-defs-test/src/test/java/com/vertispan/tsdefs/tests/inheritance/JsTypeGrandChildOfTsIgnoredParent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2024 Vertispan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vertispan.tsdefs.tests.inheritance;
+
+import jsinterop.annotations.JsType;
+
+@JsType
+public class JsTypeGrandChildOfTsIgnoredParent extends NonJsTypeTsIgnoredParent {
+
+  public String propertyFromA;
+
+  public String doSomethingFromA() {
+    return "";
+  }
+}

--- a/jsinterop-ts-defs-test/src/test/java/com/vertispan/tsdefs/tests/inheritance/NonJsTypeTsIgnoredParent.java
+++ b/jsinterop-ts-defs-test/src/test/java/com/vertispan/tsdefs/tests/inheritance/NonJsTypeTsIgnoredParent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2024 Vertispan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vertispan.tsdefs.tests.inheritance;
+
+import com.vertispan.tsdefs.annotations.TsIgnore;
+
+@TsIgnore
+public class NonJsTypeTsIgnoredParent extends JsTypeGrandParent {
+
+  public String propertyFromB;
+
+  public String doSomethingFromB() {
+    return "";
+  }
+}

--- a/jsinterop-ts-defs-test/src/test/resources/types/test.ts
+++ b/jsinterop-ts-defs-test/src/test/resources/types/test.ts
@@ -112,6 +112,7 @@ import UnionTypeApi = com.vertispan.tsdefs.tests.tsunion.UnionTypeApi;
 
 import JsTypeGrandChild = com.vertispan.tsdefs.tests.inheritance.JsTypeGrandChild;
 import JsTypeGrandChild2 = com.vertispan.tsdefs.tests.inheritance.JsTypeGrandChild2;
+import JsTypeGrandChildOfTsIgnoredParent = com.vertispan.tsdefs.tests.inheritance.JsTypeGrandChildOfTsIgnoredParent;
 import JsTypeWithPrivateAndIgnoredConstructors = com.vertispan.tsdefs.tests.constructors.JsTypeWithPrivateAndIgnoredConstructors;
 // ---------- Properties tests -------------------------
 const jsTypeWithProperties = new JsTypeWithProperties();
@@ -562,6 +563,12 @@ jsTypeGrandChild2.doSomethingFromC();
 jsTypeGrandChild2.propertyFromB;
 // @ts-expect-error
 jsTypeGrandChild2.doSomethingFromB;
+
+const jsTypeGrandChildOfTsIgnoredParent = new JsTypeGrandChildOfTsIgnoredParent();
+jsTypeGrandChildOfTsIgnoredParent.propertyFromA;
+jsTypeGrandChildOfTsIgnoredParent.doSomethingFromA();
+jsTypeGrandChildOfTsIgnoredParent.propertyFromC;
+jsTypeGrandChildOfTsIgnoredParent.doSomethingFromC();
 
 // ------------------------ TsName ---------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,14 +70,6 @@
 
     </properties>
 
-    <modules>
-        <module>jsinterop-ts-defs-processor</module>
-        <module>jsinterop-ts-defs-annotations</module>
-        <module>jsinterop-ts-defs-impl</module>
-        <module>jsinterop-ts-defs-doclet</module>
-        <module>jsinterop-ts-defs-test</module>
-    </modules>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -201,7 +193,26 @@
     </build>
     <profiles>
         <profile>
+            <id>env-dev</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>jsinterop-ts-defs-processor</module>
+                <module>jsinterop-ts-defs-annotations</module>
+                <module>jsinterop-ts-defs-impl</module>
+                <module>jsinterop-ts-defs-doclet</module>
+                <module>jsinterop-ts-defs-test</module>
+            </modules>
+        </profile>
+        <profile>
             <id>release</id>
+            <modules>
+                <module>jsinterop-ts-defs-processor</module>
+                <module>jsinterop-ts-defs-annotations</module>
+                <module>jsinterop-ts-defs-impl</module>
+                <module>jsinterop-ts-defs-doclet</module>
+            </modules>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
Having TsIgnore on a parent class prevents the recursive traverse of its super classes.

fix #99