### PR TITLE
Emit literals as `<code></code>` instead of using "`"

### DIFF
--- a/jsinterop-ts-defs-doclet/src/main/java/com/vertispan/tsdefs/doclet/TsDocTreeVisitor.java
+++ b/jsinterop-ts-defs-doclet/src/main/java/com/vertispan/tsdefs/doclet/TsDocTreeVisitor.java
@@ -139,12 +139,7 @@ public class TsDocTreeVisitor extends SimpleDocTreeVisitor<String, Element> {
   @Override
   public String visitLiteral(LiteralTree node, Element element) {
     if (nonNull(node.getBody())) {
-      String body = node.getBody().getBody();
-      String wrap = "`";
-      if (body.contains(System.lineSeparator())) {
-        wrap = "```";
-      }
-      return wrap + node.getBody().getBody() + wrap;
+      return "<code>" + node.getBody().getBody() + "</code>";
     }
     return super.visitLiteral(node, element);
   }

--- a/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/DocletTest.java
+++ b/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/DocletTest.java
@@ -72,4 +72,9 @@ public class DocletTest {
   public void testIssue99() throws IOException {
     testDocs("links.issue99");
   }
+
+  @Test
+  public void testIssue104() throws IOException {
+    testDocs("links.issue104");
+  }
 }

--- a/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/links/issue104/JsTypeWithCodeTagDocs.java
+++ b/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/links/issue104/JsTypeWithCodeTagDocs.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2024 Vertispan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vertispan.tsdefs.tests.tsdocs.doclet.links.issue104;
+
+import jsinterop.annotations.JsType;
+
+/**
+ * This is a JsType to test {@code code snippet} in docs <i>example {@code code snippet a} in
+ * tags</i> and we also test
+ *
+ * <ul>
+ *   <li>example {@code code snippet b} in tags
+ * </ul>
+ *
+ * {@code code snippet c}
+ */
+@JsType
+public class JsTypeWithCodeTagDocs {
+
+  /**
+   * This is a field to test {@code code snippet} in docs <i>example {@code code snippet a} in
+   * tags</i> and we also test
+   *
+   * <ul>
+   *   <li>example {@code code snippet b} in tags
+   * </ul>
+   *
+   * {@code code snippet c}
+   */
+  public String field;
+
+  /**
+   * This is a method to test {@code code snippet} in docs <i>example {@code code snippet a} in
+   * tags</i> and we also test
+   *
+   * <ul>
+   *   <li>example {@code code snippet b} in tags
+   * </ul>
+   *
+   * {@code code snippet c}
+   */
+  public void doSomething() {
+    return;
+  }
+}


### PR DESCRIPTION
Using `<code></code>` works consistently inside different documentation html tags

fix #104