### PR TITLE
Emit consistent jsdocs for inherited members

### DIFF
--- a/jsinterop-ts-defs-doclet/src/main/java/com/vertispan/tsdefs/doclet/TsDocTreeVisitor.java
+++ b/jsinterop-ts-defs-doclet/src/main/java/com/vertispan/tsdefs/doclet/TsDocTreeVisitor.java
@@ -166,4 +166,9 @@ public class TsDocTreeVisitor extends SimpleDocTreeVisitor<String, Element> {
             .map(docTree -> docTree.accept(this, element))
             .collect(Collectors.joining());
   }
+
+  @Override
+  public String visitInheritDoc(InheritDocTree node, Element element) {
+    return "@inheritDoc";
+  }
 }

--- a/jsinterop-ts-defs-doclet/src/main/java/com/vertispan/tsdefs/doclet/TsDoclet.java
+++ b/jsinterop-ts-defs-doclet/src/main/java/com/vertispan/tsdefs/doclet/TsDoclet.java
@@ -25,6 +25,7 @@ import com.vertispan.tsdefs.annotations.TsModule;
 import com.vertispan.tsdefs.impl.Formatting;
 import com.vertispan.tsdefs.impl.HasProcessorEnv;
 import com.vertispan.tsdefs.impl.LogWrapper;
+import com.vertispan.tsdefs.impl.builders.TsElement;
 import com.vertispan.tsdefs.impl.model.TsDoc;
 import com.vertispan.tsdefs.impl.model.TypeScriptModule;
 import com.vertispan.tsdefs.impl.visitors.TypeVisitor;
@@ -215,8 +216,17 @@ public class TsDoclet implements Doclet, HasProcessorEnv {
             Optional.ofNullable(path).map(treePath -> env.getDocTrees().getDocCommentTree(path));
         return docCommentTree
             .map(doctree -> TsDoc.of(doctree.accept(new TsDocTreeVisitor(this, this.env), element)))
-            .orElse(TsDoc.empty());
+            .orElse(inheritedDocsOrEmpty(element));
       }
+    }
+    return inheritedDocsOrEmpty(element);
+  }
+
+  private TsDoc inheritedDocsOrEmpty(Element element) {
+
+    TsElement tsElement = TsElement.of(element, this);
+    if (tsElement.overridesAnyMethod()) {
+      return TsDoc.inherited();
     }
     return TsDoc.empty();
   }

--- a/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/DocletTest.java
+++ b/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/DocletTest.java
@@ -77,4 +77,9 @@ public class DocletTest {
   public void testIssue104() throws IOException {
     testDocs("links.issue104");
   }
+
+  @Test
+  public void testIssue106() throws IOException {
+    testDocs("links.issue106");
+  }
 }

--- a/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/links/issue106/ChildJsType.java
+++ b/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/links/issue106/ChildJsType.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2024 Vertispan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vertispan.tsdefs.tests.tsdocs.doclet.links.issue106;
+
+import jsinterop.annotations.JsType;
+
+@JsType
+public class ChildJsType extends SuperJsType implements SuperInterface {
+  /** This method is documented in the child */
+  @Override
+  public void doSomething() {}
+
+  /** This method is documented in the child and inherits the parent docs. {@inheritDoc} */
+  @Override
+  public void doSomethingElse() {}
+
+  @Override
+  public void doSomethingDifferent() {
+    super.doSomethingDifferent();
+  }
+
+  @Override
+  public void deprecatedDoSomething() {
+    super.deprecatedDoSomething();
+  }
+
+  @Override
+  public void doFoo() {}
+
+  @Override
+  public void doBarDeprecated() {}
+}

--- a/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/links/issue106/SuperInterface.java
+++ b/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/links/issue106/SuperInterface.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2024 Vertispan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vertispan.tsdefs.tests.tsdocs.doclet.links.issue106;
+
+public interface SuperInterface {
+
+  /** This is documented in the super interface */
+  void doFoo();
+
+  @Deprecated
+  void doBarDeprecated();
+}

--- a/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/links/issue106/SuperJsType.java
+++ b/jsinterop-ts-defs-doclet/src/test/java/com/vertispan/tsdefs/tests/tsdocs/doclet/links/issue106/SuperJsType.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2024 Vertispan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vertispan.tsdefs.tests.tsdocs.doclet.links.issue106;
+
+import jsinterop.annotations.JsType;
+
+@JsType
+public class SuperJsType {
+
+  public void doSomething() {}
+
+  /** This is the super type documentation */
+  public void doSomethingElse() {}
+
+  /** This is documented in the super type */
+  public void doSomethingDifferent() {}
+
+  @Deprecated
+  public void deprecatedDoSomething() {}
+}

--- a/jsinterop-ts-defs-impl/src/main/java/com/vertispan/tsdefs/impl/model/TsDoc.java
+++ b/jsinterop-ts-defs-impl/src/main/java/com/vertispan/tsdefs/impl/model/TsDoc.java
@@ -32,6 +32,10 @@ public class TsDoc {
     return TsDoc.of("");
   }
 
+  public static TsDoc inherited() {
+    return TsDoc.of(" @inheritDoc");
+  }
+
   private TsDoc(String docs) {
     this.docs = docs;
   }


### PR DESCRIPTION
Mark method as deprecated if recursively it overrides a deprecated method, and adds inheritDoc tag if the overriding method does not provide its own documentation.

fix #106