### PR TITLE
Allow native interfaces to be exported when they are annotated with "@TsInterface"

### DIFF
--- a/jsinterop-ts-defs-doclet/src/main/java/com/vertispan/tsdefs/doclet/TsDoclet.java
+++ b/jsinterop-ts-defs-doclet/src/main/java/com/vertispan/tsdefs/doclet/TsDoclet.java
@@ -20,6 +20,7 @@ import static java.util.Objects.nonNull;
 
 import com.sun.source.doctree.DocCommentTree;
 import com.sun.source.util.TreePath;
+import com.vertispan.tsdefs.annotations.TsInterface;
 import com.vertispan.tsdefs.annotations.TsModule;
 import com.vertispan.tsdefs.impl.Formatting;
 import com.vertispan.tsdefs.impl.HasProcessorEnv;
@@ -106,7 +107,8 @@ public class TsDoclet implements Doclet, HasProcessorEnv {
               .filter(
                   element ->
                       nonNull(element.getAnnotation(JsType.class))
-                          && !element.getAnnotation(JsType.class).isNative())
+                          && (!element.getAnnotation(JsType.class).isNative()
+                              || nonNull(element.getAnnotation(TsInterface.class))))
               .collect(Collectors.toSet());
 
       Set<Element> jsFunctions =
@@ -161,7 +163,8 @@ public class TsDoclet implements Doclet, HasProcessorEnv {
           .filter(
               element ->
                   isNull(element.getAnnotation(JsType.class))
-                      || !element.getAnnotation(JsType.class).isNative())
+                      || (!element.getAnnotation(JsType.class).isNative()
+                          || nonNull(element.getAnnotation(TsInterface.class))))
           .forEach(
               e -> {
                 try {

--- a/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/processor/JsTypesProcessingStep.java
+++ b/jsinterop-ts-defs-processor/src/main/java/com/vertispan/tsdefs/processor/JsTypesProcessingStep.java
@@ -20,10 +20,12 @@
 package com.vertispan.tsdefs.processor;
 
 import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 
 import com.google.auto.common.BasicAnnotationProcessor.ProcessingStep;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
+import com.vertispan.tsdefs.annotations.TsInterface;
 import com.vertispan.tsdefs.annotations.TsModule;
 import com.vertispan.tsdefs.impl.Formatting;
 import com.vertispan.tsdefs.impl.HasProcessorEnv;
@@ -80,7 +82,10 @@ public class JsTypesProcessingStep implements ProcessingStep, HasProcessorEnv {
       // We need to exclude native types from being exported.
       Set<Element> jsTypes =
           elementsByAnnotation.get(JsType.class).stream()
-              .filter(element -> !element.getAnnotation(JsType.class).isNative())
+              .filter(
+                  element ->
+                      !element.getAnnotation(JsType.class).isNative()
+                          || (nonNull(element.getAnnotation(TsInterface.class))))
               .collect(Collectors.toSet());
 
       // We also list types that might not be annotated with JsType but have members annotated using
@@ -119,7 +124,8 @@ public class JsTypesProcessingStep implements ProcessingStep, HasProcessorEnv {
           .filter(
               element ->
                   isNull(element.getAnnotation(JsType.class))
-                      || !element.getAnnotation(JsType.class).isNative())
+                      || !element.getAnnotation(JsType.class).isNative()
+                      || (nonNull(element.getAnnotation(TsInterface.class))))
           .forEach(
               e -> {
                 try {

--- a/jsinterop-ts-defs-test/src/test/java/com/vertispan/tsdefs/tests/tsinterface/NativeInterface.java
+++ b/jsinterop-ts-defs-test/src/test/java/com/vertispan/tsdefs/tests/tsinterface/NativeInterface.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2023 Vertispan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vertispan.tsdefs.tests.tsinterface;
+
+import com.vertispan.tsdefs.annotations.TsInterface;
+import jsinterop.annotations.JsType;
+
+@TsInterface
+@JsType(isNative = true)
+public interface NativeInterface {
+
+  void doSomething();
+}

--- a/jsinterop-ts-defs-test/src/test/java/com/vertispan/tsdefs/tests/tsinterface/NotAnnotatedNativeInterface.java
+++ b/jsinterop-ts-defs-test/src/test/java/com/vertispan/tsdefs/tests/tsinterface/NotAnnotatedNativeInterface.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2023 Vertispan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vertispan.tsdefs.tests.tsinterface;
+
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true)
+public interface NotAnnotatedNativeInterface {
+
+  void doSomething();
+}

--- a/jsinterop-ts-defs-test/src/test/resources/types/test.ts
+++ b/jsinterop-ts-defs-test/src/test/resources/types/test.ts
@@ -45,6 +45,8 @@ import JsTypeWithSettersAndGetters = com.vertispan.tsdefs.tests.settergetter.JsT
 import JsTypeInterface = com.vertispan.tsdefs.tests.interfaces.JsTypeInterface;
 import JsTypeChild = com.vertispan.tsdefs.tests.inheritance.JsTypeChild;
 import JsInterfaceByTsName = com.vertispan.tsdefs.tests.tsname.JsInterfaceByTsName;
+import NativeInterface = com.vertispan.tsdefs.tests.tsinterface.NativeInterface;
+
 // @ts-expect-error
 import JsInterfaceWithTsName = com.vertispan.tsdefs.tests.tsname.JsInterfaceWithTsName;
 // @ts-expect-error
@@ -98,6 +100,8 @@ import JsTypeAsTsInterface = com.vertispan.tsdefs.tests.tsinterface.JsTypeAsTsIn
 
 import JsTypeWithStaticMethods = com.vertispan.tsdefs.tests.methods.JsTypeWithStaticMethods;
 
+// @ts-expect-error
+import NotAnnotatedNativeInterface = com.vertispan.tsdefs.tests.tsinterface.NotAnnotatedNativeInterface;
 // ---------- JsNullable ---------------
 
 import JsInterfaceWithJsNullableSetGet = com.vertispan.tsdefs.tests.jsnullable.JsInterfaceWithJsNullableSetGet
@@ -480,6 +484,16 @@ implementingJsTypeInterface.getPropertyA();
 implementingJsTypeInterface.setPropertyA("text");
 // TODO: What should we do with methods in interfaces and the method define a different namespace
 implementingJsTypeInterface.methodFromJsTypeInterface();
+
+class ImplementingNativeInterface implements NativeInterface {
+
+    doSomething(): void {
+        return;
+    }
+}
+
+const implementingNativeInterface = new ImplementingNativeInterface();
+implementingNativeInterface.doSomething();
 
 // ------------------ Inheritance ------------------------
 

--- a/jsinterop-ts-defs-test/src/test/resources/types/tsconfig.json
+++ b/jsinterop-ts-defs-test/src/test/resources/types/tsconfig.json
@@ -14,6 +14,7 @@
     // If the library is an external module (uses `export`), this allows your test file to import "mylib" instead of "./index".
     // If the library is global (cannot be imported via `import` or `require`), leave this out.
     "baseUrl": "../types",
-    "paths": { "tsinterop": ["./../generated-test-sources/test-annotations/types"] }
+    "paths": { "tsinterop": ["./../generated-test-sources/test-annotations/types"] },
+    "ignoreDeprecations": "6.0"
   }
 }


### PR DESCRIPTION
fix #113